### PR TITLE
Set gem references to proper public versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,10 @@ group :production do
   gem "rails_12factor"
 end
 
+gem "reform", '2.1.0'
 # gem "reform", github: "apotonick/reform", branch: "reform-2"
-gem "reform", path: "../reform"
+#gem "reform", path: "../reform"
+
 # gem "representable", path: "../representable"
 gem "representable", "2.4.0"
 # gem "reform", "2.0.4"
@@ -40,13 +42,16 @@ gem "representable", "2.4.0"
 gem "virtus"
 
 # gem "disposable", path: "../disposable"
-gem "tyrant", path: "../tyrant"
-# gem "tyrant", "0.0.2"
+gem "tyrant", "0.0.2"
+# gem "tyrant", path: "../tyrant"
 
-# gem "trailblazer", "1.0.1"
-gem "trailblazer", path: "../trailblazer"
-gem "trailblazer-loader", path: "../trailblazer-loader"
-gem "trailblazer-rails", path: "../trailblazer-rails"
+gem "trailblazer", "1.1.0"
+gem "trailblazer-loader", '0.0.1'
+gem "trailblazer-rails", '0.2.0'
+# gem "trailblazer", path: "../trailblazer"
+# gem "trailblazer-loader", path: "../trailblazer-loader"
+# gem "trailblazer-rails", path: "../trailblazer-rails"
+
 # gem "disposable", path: "../disposable"
 # gem "trailblazer-rails", ">= 0.1.3"
 # gem "cells", git: "https://github.com/apotonick/cells"
@@ -58,8 +63,8 @@ gem "kaminari-cells"
 
 gem "paperdragon", ">= 0.0.10"
 gem "file_validators", "~> 1.2"
-gem "roar", path: "../roar" #"1.0.0"
-# gem "roar", "1.0.2"
+# gem "roar", path: "../roar" #"1.0.0"
+gem "roar", "1.0.3"
 
 gem "pundit"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,49 +6,6 @@ GIT
     haml (4.1.0.beta.1)
       tilt
 
-PATH
-  remote: ../reform
-  specs:
-    reform (2.1.0.pre1)
-      disposable (>= 0.2.0, < 0.3.0)
-      representable (>= 2.4.0, < 3.1.0)
-      uber (~> 0.0.11)
-
-PATH
-  remote: ../roar
-  specs:
-    roar (1.0.3)
-      representable (>= 2.4.0, < 3.1.0)
-
-PATH
-  remote: ../trailblazer
-  specs:
-    trailblazer (1.1.0.pre1)
-      declarative
-      reform (>= 2.0.0, < 3.0.0)
-      uber (>= 0.0.15)
-
-PATH
-  remote: ../trailblazer-loader
-  specs:
-    trailblazer-loader (0.0.1)
-
-PATH
-  remote: ../trailblazer-rails
-  specs:
-    trailblazer-rails (0.1.6)
-      trailblazer (>= 1.0.4)
-
-PATH
-  remote: ../tyrant
-  specs:
-    tyrant (0.0.2)
-      bcrypt
-      disposable (>= 0.1.11)
-      reform (~> 2.0)
-      trailblazer (~> 1.0)
-      warden
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -128,7 +85,7 @@ GEM
       uber (>= 0.0.15)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    disposable (0.2.0)
+    disposable (0.2.5)
       declarative (~> 0.0.4)
       representable (>= 2.4.0, <= 3.1.0)
       uber
@@ -256,11 +213,17 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     ref (2.0.0)
+    reform (2.1.0)
+      disposable (>= 0.2.2, < 0.3.0)
+      representable (>= 2.4.0, < 3.1.0)
+      uber (~> 0.0.11)
     representable (2.4.0)
       declarative (~> 0.0.5)
       uber (~> 0.0.15)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    roar (1.0.3)
+      representable (>= 2.0.1, <= 3.0.0)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
     sass (3.2.19)
@@ -293,6 +256,19 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    trailblazer (1.1.0)
+      declarative
+      reform (>= 2.0.0, < 3.0.0)
+      uber (>= 0.0.15)
+    trailblazer-loader (0.0.1)
+    trailblazer-rails (0.2.0)
+      trailblazer (>= 1.0.4)
+      trailblazer-loader (>= 0.0.1)
+    tyrant (0.0.2)
+      bcrypt
+      disposable (>= 0.1.11)
+      reform (~> 2.0)
+      trailblazer
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -304,8 +280,6 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.3)
-      rack (>= 1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -336,19 +310,19 @@ DEPENDENCIES
   rails-timeago
   rails_12factor
   rails_layout
-  reform!
+  reform (= 2.1.0)
   representable (= 2.4.0)
   responders
-  roar!
+  roar (= 1.0.3)
   sass-rails (~> 4.0.3)
   simple_form
   sqlite3
   therubyracer
   thin
-  trailblazer!
-  trailblazer-loader!
-  trailblazer-rails!
-  tyrant!
+  trailblazer (= 1.1.0)
+  trailblazer-loader (= 0.0.1)
+  trailblazer-rails (= 0.2.0)
+  tyrant (= 0.0.2)
   uglifier (>= 1.3.0)
   virtus
 


### PR DESCRIPTION
Could not run the tests nor the rails server as the `Gemfile` pointed to your local development versions of other `trailblazer` gems.

This updates the gems to point to the versions numbers matching the `Gemfile.lock`.

The only case this isn't true is for `trailblazer-rails` which referenced version `0.1.6`. I updated this to `0.2.0` as that was when [`trailblazer/rails/test/integration`](https://github.com/trailblazer/trailblazer-rails/blob/v0.2.0/lib/trailblazer/rails/test/integration.rb) was introduced. Which is a breaking dependency for Mintiest. 

I debated removing the commented code out of the Gemfile as it can be restored via git, but was not sure which way would be preferred.