### PR TITLE
Improve branches table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ For each chapter there is a corresponding branch.
 
 Chapter | Branch | Compare
 --- | --- | ---
-03: Operations and Forms | https://github.com/apotonick/gemgem-trbrb/tree/chapter-03 | |
-04: Cells | https://github.com/apotonick/gemgem-trbrb/tree/chapter-04 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-03...chapter-04 |
-05: Nested Forms | https://github.com/apotonick/gemgem-trbrb/tree/chapter-05 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-04...chapter-05 |
-06: Composed Views | https://github.com/apotonick/gemgem-trbrb/tree/chapter-06 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-05...chapter-06 |
-07: Mastering Forms | https://github.com/apotonick/gemgem-trbrb/tree/chapter-07 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-06...chapter-07 |
-08: Callbacks | https://github.com/apotonick/gemgem-trbrb/tree/chapter-08 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-07...chapter-08 |
-09: Authentication | https://github.com/apotonick/gemgem-trbrb/tree/chapter-09 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-08...chapter-09 |
-10: Authorization and Polymorphism | https://github.com/apotonick/gemgem-trbrb/tree/chapter-10 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-09...chapter-10 |
-11: Hypermedia APIs: Rendering | https://github.com/apotonick/gemgem-trbrb/tree/chapter-11 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11 |
-11: Hypermedia APIs: Deserialization | https://github.com/apotonick/gemgem-trbrb/tree/chapter-11 | https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11 |
+03: Operations and Forms | [chapter-03](https://github.com/apotonick/gemgem-trbrb/tree/chapter-03) |
+04: Cells | [chapter-04](https://github.com/apotonick/gemgem-trbrb/tree/chapter-04) | [chapter-03...chapter-04](https://github.com/apotonick/gemgem-trbrb/compare/chapter-03...chapter-04) |
+05: Nested Forms | [chapter-05](https://github.com/apotonick/gemgem-trbrb/tree/chapter-05) | [chapter-04...chapter-05](https://github.com/apotonick/gemgem-trbrb/compare/chapter-04...chapter-05) |
+06: Composed Views | [chapter-06](https://github.com/apotonick/gemgem-trbrb/tree/chapter-06) | [chapter-05...chapter-06](https://github.com/apotonick/gemgem-trbrb/compare/chapter-05...chapter-06) |
+07: Mastering Forms | [chapter-07](https://github.com/apotonick/gemgem-trbrb/tree/chapter-07) | [chapter-06...chapter-07](https://github.com/apotonick/gemgem-trbrb/compare/chapter-06...chapter-07) |
+08: Callbacks | [chapter-08](https://github.com/apotonick/gemgem-trbrb/tree/chapter-08) | [chapter-07...chapter-08](https://github.com/apotonick/gemgem-trbrb/compare/chapter-07...chapter-08) |
+09: Authentication | [chapter-09](https://github.com/apotonick/gemgem-trbrb/tree/chapter-09) | [chapter-08...chapter-09](https://github.com/apotonick/gemgem-trbrb/compare/chapter-08...chapter-09) |
+10: Authorization and Polymorphism | [chapter-10](https://github.com/apotonick/gemgem-trbrb/tree/chapter-10) | [chapter-09...chapter-10](https://github.com/apotonick/gemgem-trbrb/compare/chapter-09...chapter-10) |
+11: Hypermedia APIs: Rendering | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
+11: Hypermedia APIs: Deserialization | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
 
 If you find bugs, please try to fix them in the corresponding chapter branch, I'll do the rest! :)

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Thanks so much!
 
 For each chapter there is a corresponding branch.
 
-Chapter | Branch | Compare
---- | --- | ---
-03: Operations and Forms | [chapter-03](https://github.com/apotonick/gemgem-trbrb/tree/chapter-03) |
-04: Cells | [chapter-04](https://github.com/apotonick/gemgem-trbrb/tree/chapter-04) | [chapter-03...chapter-04](https://github.com/apotonick/gemgem-trbrb/compare/chapter-03...chapter-04) |
-05: Nested Forms | [chapter-05](https://github.com/apotonick/gemgem-trbrb/tree/chapter-05) | [chapter-04...chapter-05](https://github.com/apotonick/gemgem-trbrb/compare/chapter-04...chapter-05) |
-06: Composed Views | [chapter-06](https://github.com/apotonick/gemgem-trbrb/tree/chapter-06) | [chapter-05...chapter-06](https://github.com/apotonick/gemgem-trbrb/compare/chapter-05...chapter-06) |
-07: Mastering Forms | [chapter-07](https://github.com/apotonick/gemgem-trbrb/tree/chapter-07) | [chapter-06...chapter-07](https://github.com/apotonick/gemgem-trbrb/compare/chapter-06...chapter-07) |
-08: Callbacks | [chapter-08](https://github.com/apotonick/gemgem-trbrb/tree/chapter-08) | [chapter-07...chapter-08](https://github.com/apotonick/gemgem-trbrb/compare/chapter-07...chapter-08) |
-09: Authentication | [chapter-09](https://github.com/apotonick/gemgem-trbrb/tree/chapter-09) | [chapter-08...chapter-09](https://github.com/apotonick/gemgem-trbrb/compare/chapter-08...chapter-09) |
-10: Authorization and Polymorphism | [chapter-10](https://github.com/apotonick/gemgem-trbrb/tree/chapter-10) | [chapter-09...chapter-10](https://github.com/apotonick/gemgem-trbrb/compare/chapter-09...chapter-10) |
-11: Hypermedia APIs: Rendering | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
-11: Hypermedia APIs: Deserialization | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
+N | Chapter | Branch | Compare
+--- | --- | --- | ---
+03 | Operations and Forms | [chapter-03](https://github.com/apotonick/gemgem-trbrb/tree/chapter-03) |
+04 | Cells | [chapter-04](https://github.com/apotonick/gemgem-trbrb/tree/chapter-04) | [chapter-03...chapter-04](https://github.com/apotonick/gemgem-trbrb/compare/chapter-03...chapter-04) |
+05 | Nested Forms | [chapter-05](https://github.com/apotonick/gemgem-trbrb/tree/chapter-05) | [chapter-04...chapter-05](https://github.com/apotonick/gemgem-trbrb/compare/chapter-04...chapter-05) |
+06 | Composed Views | [chapter-06](https://github.com/apotonick/gemgem-trbrb/tree/chapter-06) | [chapter-05...chapter-06](https://github.com/apotonick/gemgem-trbrb/compare/chapter-05...chapter-06) |
+07 | Mastering Forms | [chapter-07](https://github.com/apotonick/gemgem-trbrb/tree/chapter-07) | [chapter-06...chapter-07](https://github.com/apotonick/gemgem-trbrb/compare/chapter-06...chapter-07) |
+08 | Callbacks | [chapter-08](https://github.com/apotonick/gemgem-trbrb/tree/chapter-08) | [chapter-07...chapter-08](https://github.com/apotonick/gemgem-trbrb/compare/chapter-07...chapter-08) |
+09 | Authentication | [chapter-09](https://github.com/apotonick/gemgem-trbrb/tree/chapter-09) | [chapter-08...chapter-09](https://github.com/apotonick/gemgem-trbrb/compare/chapter-08...chapter-09) |
+10 | Authorization and Polymorphism | [chapter-10](https://github.com/apotonick/gemgem-trbrb/tree/chapter-10) | [chapter-09...chapter-10](https://github.com/apotonick/gemgem-trbrb/compare/chapter-09...chapter-10) |
+11 | Hypermedia APIs: Rendering | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
+11 | Hypermedia APIs: Deserialization | [chapter-11](https://github.com/apotonick/gemgem-trbrb/tree/chapter-11) | [chapter-10...chapter-11](https://github.com/apotonick/gemgem-trbrb/compare/chapter-10...chapter-11) |
 
 If you find bugs, please try to fix them in the corresponding chapter branch, I'll do the rest! :)


### PR DESCRIPTION
The chapter branches tables is being cut in my display.
Here is just a suggestion for a new layout for it.
Feel free to merge it or drop it.

Before
=====

![captura de tela 2016-04-04 as 11 29 56](https://cloud.githubusercontent.com/assets/551790/14251624/3e3366b4-fa5a-11e5-9663-08434e238672.png)

After
======

![captura de tela 2016-04-04 as 11 40 09](https://cloud.githubusercontent.com/assets/551790/14251629/43f870d0-fa5a-11e5-9212-b77a523e2367.png)
