### PR TITLE
Add missing gem for Rails 5 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "pg"
 gem "responders"
 
 group :development, :test do
+  gem "minitest-spec-rails"
   gem "minitest-rails-capybara"
   gem "minitest-line"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       minitest-capybara (~> 0.7.0)
       minitest-metadata (~> 0.5.0)
       minitest-rails (~> 2.1)
+    minitest-spec-rails (5.4.0)
+      minitest (~> 5.0)
+      rails (>= 4.1)
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -316,6 +319,7 @@ DEPENDENCIES
   memory_test_fix
   minitest-line
   minitest-rails-capybara
+  minitest-spec-rails
   paperdragon (>= 0.0.10)
   pg
   pundit
@@ -339,4 +343,4 @@ DEPENDENCIES
   virtus
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
The gem `minitest-spec-rails` is required for this to work in Rails 5, suggested for prior versions.